### PR TITLE
Add ci-module files ecr.tf, variables.tf. Call ci-module from dev/ci.tf

### DIFF
--- a/environments/dev/ci.tf
+++ b/environments/dev/ci.tf
@@ -1,0 +1,4 @@
+module "ci-setup" {
+  source              = "../../modules/ci"
+  ecr_repository_name = "test-container-repo"
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -23,6 +23,13 @@ terraform {
 
 provider "aws" {
   region = "us-east-1"
+
+  default_tags {
+    tags = {
+      Environment = "Dev"
+      Name        = "managed-by-terraform"
+    }
+  }
 }
 
 

--- a/modules/ci/ecr.tf
+++ b/modules/ci/ecr.tf
@@ -1,0 +1,13 @@
+resource "aws_ecr_repository" "kiosk-container-repo" {
+  name                 = var.ecr_repository_name
+  image_tag_mutability = "IMMUTABLE"
+
+  # Encryption settings for a repository can't be changed after creation.
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/modules/ci/variables.tf
+++ b/modules/ci/variables.tf
@@ -1,0 +1,4 @@
+variable "ecr_repository_name" {
+  description = "The name of the ECR repository"
+  type        = string
+}


### PR DESCRIPTION
Setup ECR registry in modules/ci/ecr.tf per [TF Docs: Resource: aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#registry_id-1)
- ECR images tags shouldn't be mutable. [per acquasecurity.github.io](https://aquasecurity.github.io/tfsec/v1.6.2/checks/aws/ecr/enforce-immutable-repository/)
- Setup modules/ci/variable.tf to define variables to be used within the ci module.  (not sure if we'll need different ECR repositories for each environment ... easier to do if I define the variable now). 

Added "default_tags" to provider "aws" in dev/main.tf per [TF Docs: AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block)

Called the new ci module in the dev environment via: /environments/dev/ci.tf 
- provide variable value needed in the ci-module in the environments/dev/ci.tf 
Ex. `ecr_repository_name = "test-container-repo"`.   
Even though the variable definition is in the module/ci/variables.tf directory. 
