### PR TITLE
EC2 testing

### DIFF
--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 4.16"
   hashes = [
     "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "h1:LfOuBkdYCzQhtiRvVIxdP/KGJODa3cRsKjn8xKCTbVY=",
     "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
     "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
     "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",

--- a/environments/dev/ci.tf
+++ b/environments/dev/ci.tf
@@ -1,4 +1,5 @@
 module "ci-setup" {
   source              = "../../modules/ci"
   ecr_repository_name = "test-container-repo"
+  ec2_instance_name   = "Kiosk-EC2"
 }

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -11,6 +11,7 @@ terraform {
   backend "s3" {
     # Match the S3 bucket name already created in backend.tf
     bucket = "kiosk-tf-s3-bucket"
+
     # Path in the bucket to store the state file
     key = "dev/terraform-state/terraform.tfstate"
     # Region where the bucket is located

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -32,13 +32,3 @@ provider "aws" {
     }
   }
 }
-
-
-resource "aws_instance" "tf_instance" {
-  ami           = "ami-0c02fb55956c7d316" # Amazon Linux 2 AMI
-  instance_type = "t2.micro"
-
-  tags = {
-    Name = "Test-EC2-Instance"
-  }
-}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -10,7 +10,7 @@ terraform {
 
   backend "s3" {
     # Match the S3 bucket name already created in backend.tf
-    bucket = "kiosk-tf-s3-bucket-jen"
+    bucket = "kiosk-tf-s3-bucket"
     # Path in the bucket to store the state file
     key = "dev/terraform-state/terraform.tfstate"
     # Region where the bucket is located

--- a/modules/ci/.terraform.lock.hcl
+++ b/modules/ci/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.82.2"
+  hashes = [
+    "h1:xeNk4aWj5/bjPodhIu26+AGKLnqlSEqev7dsOhIDUUQ=",
+    "zh:0262fc96012fb7e173e1b7beadd46dfc25b1dc7eaef95b90e936fc454724f1c8",
+    "zh:397413613d27f4f54d16efcbf4f0a43c059bd8d827fe34287522ae182a992f9b",
+    "zh:436c0c5d56e1da4f0a4c13129e12a0b519d12ab116aed52029b183f9806866f3",
+    "zh:4d942d173a2553d8d532a333a0482a090f4e82a2238acf135578f163b6e68470",
+    "zh:624aebc549bfbce06cc2ecfd8631932eb874ac7c10eb8466ce5b9a2fbdfdc724",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e632dee2dfdf01b371cca7854b1ec63ceefa75790e619b0642b34d5514c6733",
+    "zh:a07567acb115b60a3df8f6048d12735b9b3bcf85ec92a62f77852e13d5a3c096",
+    "zh:ab7002df1a1be6432ac0eb1b9f6f0dd3db90973cd5b1b0b33d2dae54553dfbd7",
+    "zh:bc1ff65e2016b018b3e84db7249b2cd0433cb5c81dc81f9f6158f2197d6b9fde",
+    "zh:bcad84b1d767f87af6e1ba3dc97fdb8f2ad5de9224f192f1412b09aba798c0a8",
+    "zh:cf917dceaa0f9d55d9ff181b5dcc4d1e10af21b6671811b315ae2a6eda866a2a",
+    "zh:d8e90ecfb3216f3cc13ccde5a16da64307abb6e22453aed2ac3067bbf689313b",
+    "zh:d9054e0e40705df729682ad34c20db8695d57f182c65963abd151c6aba1ab0d3",
+    "zh:ecf3a4f3c57eb7e89f71b8559e2a71e4cdf94eea0118ec4f2cb37e4f4d71a069",
+  ]
+}

--- a/modules/ci/ec2.tf
+++ b/modules/ci/ec2.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "tf_instance" {
+  ami           = "ami-0c02fb55956c7d316" # Amazon Linux 2 AMI
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = var.ec2_instance_name
+  }
+}

--- a/modules/ci/variables.tf
+++ b/modules/ci/variables.tf
@@ -2,3 +2,9 @@ variable "ecr_repository_name" {
   description = "The name of the ECR repository"
   type        = string
 }
+
+variable "ec2_instance_name" {
+  description = "The name of the EC2 instance"
+  type        = string
+}
+


### PR DESCRIPTION
```hcl

PS C:\Users\datla\OneDrive\Desktop\kiosk-terraform\environments\dev> terraform plan
var.environment
  The deployment environment: dev, sqa, preprod, or prod

  Enter a value: dev

module.ci-setup.aws_ecr_repository.kiosk-container-repo: Refreshing state... [id=test-container-repo]
aws_instance.tf_instance: Refreshing state... [id=i-03c0e0e7864481859]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # aws_instance.tf_instance will be destroyed
  # (because aws_instance.tf_instance is not in configuration)
  - resource "aws_instance" "tf_instance" {
      - ami                                  = "ami-0c02fb55956c7d316" -> null
      - arn                                  = "arn:aws:ec2:us-east-1:536697245609:instance/i-03c0e0e7864481859" -> null
      - associate_public_ip_address          = true -> null
      - availability_zone                    = "us-east-1c" -> null
      - cpu_core_count                       = 1 -> null
      - cpu_threads_per_core                 = 1 -> null
      - disable_api_stop                     = false -> null
      - disable_api_termination              = false -> null
      - ebs_optimized                        = false -> null
      - get_password_data                    = false -> null
      - hibernation                          = false -> null
      - id                                   = "i-03c0e0e7864481859" -> null
      - instance_initiated_shutdown_behavior = "stop" -> null
      - instance_state                       = "running" -> null
      - instance_type                        = "t2.micro" -> null
      - ipv6_address_count                   = 0 -> null
      - ipv6_addresses                       = [] -> null
      - monitoring                           = false -> null
      - placement_partition_number           = 0 -> null
      - primary_network_interface_id         = "eni-0a419917a9b0a2d6b" -> null
      - private_dns                          = "ip-172-31-17-241.ec2.internal" -> null
      - private_ip                           = "172.31.17.241" -> null
      - public_dns                           = "ec2-54-242-245-213.compute-1.amazonaws.com" -> null
      - public_ip                            = "54.242.245.213" -> null
      - secondary_private_ips                = [] -> null
      - security_groups                      = [
          - "default",
        ] -> null
      - source_dest_check                    = true -> null
      - subnet_id                            = "subnet-0a2e45ba00e8a8a77" -> null
      - tags                                 = {
          - "Name" = "Test-EC2-Instance"
        } -> null
      - tags_all                             = {
          - "Environment" = "Dev"
          - "Name"        = "Test-EC2-Instance"
        } -> null
      - tenancy                              = "default" -> null
      - user_data_replace_on_change          = false -> null
      - vpc_security_group_ids               = [
          - "sg-09544b6f9279f20f8",
        ] -> null
        # (6 unchanged attributes hidden)

      - capacity_reservation_specification {
          - capacity_reservation_preference = "open" -> null
        }

      - cpu_options {
          - core_count       = 1 -> null
          - threads_per_core = 1 -> null
            # (1 unchanged attribute hidden)
        }

      - credit_specification {
          - cpu_credits = "standard" -> null
        }

      - enclave_options {
          - enabled = false -> null
        }

      - maintenance_options {
          - auto_recovery = "default" -> null
        }

      - metadata_options {
          - http_endpoint               = "enabled" -> null
          - http_put_response_hop_limit = 1 -> null
          - http_tokens                 = "optional" -> null
          - instance_metadata_tags      = "disabled" -> null
        }

      - private_dns_name_options {
          - enable_resource_name_dns_a_record    = false -> null
          - enable_resource_name_dns_aaaa_record = false -> null
          - hostname_type                        = "ip-name" -> null
        }

      - root_block_device {
          - delete_on_termination = true -> null
          - device_name           = "/dev/xvda" -> null
          - encrypted             = false -> null
          - iops                  = 100 -> null
          - tags                  = {} -> null
          - throughput            = 0 -> null
          - volume_id             = "vol-0770fb8fb8ceb4c75" -> null
          - volume_size           = 8 -> null
          - volume_type           = "gp2" -> null
            # (1 unchanged attribute hidden)
        }
    }

  # module.ci-setup.aws_instance.tf_instance will be created
  + resource "aws_instance" "tf_instance" {
      + ami                                  = "ami-0c02fb55956c7d316"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = (known after apply)
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = (known after apply)
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "Kiosk-EC2"
        }
      + tags_all                             = {
          + "Environment" = "Dev"
          + "Name"        = "Kiosk-EC2"
        }
      + tenancy                              = (known after apply)
      + user_data                            = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification (known after apply)

      + cpu_options (known after apply)

      + ebs_block_device (known after apply)

      + enclave_options (known after apply)

      + ephemeral_block_device (known after apply)

      + maintenance_options (known after apply)

      + metadata_options (known after apply)

      + network_interface (known after apply)

      + private_dns_name_options (known after apply)

      + root_block_device (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

```

# Results

After terraform apply

![image](https://github.com/user-attachments/assets/c51c568f-8107-42f8-b426-e6975a51045b)

During apply

![image](https://github.com/user-attachments/assets/1f7907d5-a391-40bf-bd6b-886ed85aaa4e)

